### PR TITLE
HTMLRenderer, Text 컴포넌트 추가

### DIFF
--- a/src/components/HTMLRenderer.tsx
+++ b/src/components/HTMLRenderer.tsx
@@ -1,0 +1,53 @@
+import parse, { domToReact, HTMLReactParserOptions, DOMNode } from 'html-react-parser';
+import React from 'react';
+
+interface Props {
+  html?: string;
+  components?: Record<string, React.ComponentType<unknown>>;
+  componentOverrides?: Record<
+    string,
+    (originalComponent: React.ComponentType<unknown>) => React.ComponentType<unknown>
+  >;
+}
+
+interface Replace {
+  name: string;
+  attribs: Record<string, string>;
+  children: DOMNode[];
+}
+
+const HTMLRenderer = ({ html = '', components = {}, componentOverrides = {} }: Props) => {
+  const resolvedComponents = Object.keys(components).reduce(
+    (acc, key) => {
+      const Comp = components[key] ?? ((props) => React.createElement(key, props));
+
+      acc[key] = Comp;
+
+      return acc;
+    },
+    { ...components }
+  );
+
+  const parserOptions = {
+    replace: ({ name, attribs, children: nodes }: Replace) => {
+      const children = nodes
+        ? domToReact(nodes, {
+            ...(parserOptions as HTMLReactParserOptions),
+          })
+        : null;
+
+      const Component = resolvedComponents[name];
+
+      if (!Component) return;
+
+      const element = React.createElement(Component, { ...attribs }, children);
+
+      // eslint-disable-next-line consistent-return
+      return element;
+    },
+  } as HTMLReactParserOptions;
+
+  return parse(html, parserOptions) as JSX.Element;
+};
+
+export default HTMLRenderer;

--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -1,0 +1,33 @@
+import styled from '@emotion/styled';
+import React, { CSSProperties, PropsWithChildren } from 'react';
+import typographies, { Typography } from 'styles/typography';
+
+interface TextProps {
+  display: CSSProperties['display'];
+  typography: Typography;
+  color: CSSProperties['color'];
+}
+
+type Props = Partial<TextProps>;
+type WrapperProps = Required<Pick<TextProps, 'typography' | 'display'>>;
+
+const Text = ({
+  children,
+  display = 'inherit',
+  typography = 'subTitle3',
+  color = 'inherit',
+}: PropsWithChildren<Props>) => (
+  <StyledSpan display={display} typography={typography} color={color}>
+    {children}
+  </StyledSpan>
+);
+
+const getFontTypography = (typography: Typography) => typographies[typography];
+
+const StyledSpan = styled.span<WrapperProps>`
+  display: ${({ display }) => display};
+  color: ${({ color }) => color};
+  ${({ typography }) => getFontTypography(typography)};
+`;
+
+export { Text };

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,5 +1,3 @@
-import { css } from '@emotion/react';
-
 import colors from './colors';
 import typography from './typography';
 

--- a/src/styles/typography.ts
+++ b/src/styles/typography.ts
@@ -148,6 +148,8 @@ const typography = {
     line-height: 15px;
     letter-spacing: -0.015em;
   `,
-};
+} as const;
+
+export type Typography = keyof typeof typography;
 
 export default typography;


### PR DESCRIPTION
- HTMLRenderer 컴포넌트 추가
  - 문자열 중간에 들어가는 마크업 용도
- Text 컴포넌트 추가


e.g
```tsx
const html = '<h1>Welcom <span>to</span>  <div>My</div>realtrip</h1>';

const Home: NextPage = () => {
  return (
    <PageWrapper>
      <Foo />
    </PageWrapper>
  );
};

const Foo = () => (
  <HTMLRenderer
    html={html}
    components={{
      span: (props) => <Text {...props} color="red" />,
      div: (props) => <Wrapper {...props} />,
    }}
  />
);

const Wrapper = styled.div`
  background-color: red;
`;
```
